### PR TITLE
Added support for multElement ts-repeat

### DIFF
--- a/example.html
+++ b/example.html
@@ -52,6 +52,33 @@
             </tbody>
         </table>
 
+        <h1>Angular Tablesort with Multi-Element ts-repeat-start & ts-repeat-end</h1>
+        <h2><em>Click Select to reveal item details.</em></h2>
+        <table border="1" ts-wrapper>
+            <thead>
+            <tr>
+                <th>Select</th>
+                <th ts-criteria="Id">Id</th>
+                <th ts-criteria="Name|lowercase" ts-default>Name</th>
+                <th ts-criteria="Price|parseFloat">Price</th>
+                <th ts-criteria="Quantity|parseInt">Quantity</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr ng-repeat-start="item in items track by item.Id" ts-repeat-start>
+                <td><input type="checkbox" ng-model="item.selected"></td>
+                <td>{{item.Id}}</td>
+                <td>{{item.Name}}</td>
+                <td>{{item.Price | currency}}</td>
+                <td>{{item.Quantity}}</td>
+            </tr>
+            <tr ng-repeat-end ts-repeat-end ng-show="item.selected">
+                <td colspan="5">{{item.Description}}</td>
+            </tr>
+            </tbody>
+        </table>
+
+
 
         <h1>Empty table</h1>
         <table border="1" ts-wrapper>
@@ -65,7 +92,7 @@
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="item in noitems" ts-repeat>
+            <tr ng-repeat="item in noitems" ts-repeat ng-click="clickRow()">
                 <td><input type="checkbox"></td>
                 <td>{{item.Id}}</td>
                 <td>{{item.Name}}</td>
@@ -81,17 +108,21 @@
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 <script src="js/angular-tablesort.js"></script>
 <script>
-    var myApp = angular.module( 'myApp', ['tableSort' ] )
+    var myApp = angular.module( 'myApp', ['tableSort'] )
             .controller( "tableTestCtrl",     function tableTestCtrl($scope)  {
                 $scope.items = [
-                    {Id: "01", Name: "A", Price: "1.00", Quantity: "1"},
-                    {Id: "02", Name: "B", Price: "10.00", Quantity: "1"},
-                    {Id: "04", Name: "C", Price: "9.50", Quantity: "10"},
-                    {Id: "03", Name: "a", Price: "9.00", Quantity: "2"},
-                    {Id: "06", Name: "b", Price: "100.00", Quantity: "2"},
-                    {Id: "05",Name: "c", Price: "1.20", Quantity: "2"}
+                    {Id: "01", Name: "A", Price: "1.00", Quantity: "1", Description: "This is the description for item A.", selected: false},
+                    {Id: "02", Name: "B", Price: "10.00", Quantity: "1", Description: "This is the description for item B.", selected: false},
+                    {Id: "04", Name: "C", Price: "9.50", Quantity: "10", Description: "This is the description for item C.", selected: false},
+                    {Id: "03", Name: "a", Price: "9.00", Quantity: "2", Description: "This is the description for item a.", selected: false},
+                    {Id: "06", Name: "b", Price: "100.00", Quantity: "2", Description: "This is the description for item b.", selected: false},
+                    {Id: "05", Name: "c", Price: "1.20", Quantity: "2", Description: "This is the description for item c.", selected: false}
                 ];
-                $scope.noitems = []
+                $scope.noitems = [];
+
+                $scope.clickRow = function () {
+                    alert('You clicked the row.');
+                }
             }
     );
 


### PR DESCRIPTION
- ts-repeat now support ng-repeat-start/-end with respective
  ts-repeat-start/-end attributes.
- Changed ts-repeat directive to clone only the “No Data” row. The
  original element(s) are now recompiled with minPriority.
- Add example multi-element table
